### PR TITLE
ci: bump Node to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   salesforce-ci:
     uses: beyond-the-cloud-dev/cicd-template/.github/workflows/salesforce-ci.yml@main
     with:
-      node-version: "20"
+      node-version: "22"
       sf-cli-version: "latest"
       scratch-org-duration: 1
       test-level: "RunLocalTests"


### PR DESCRIPTION
Bumps the CI `node-version` from 20 to 22.

`apex-code-coverage-transformer` 2.23.1+ requires Node `>=22` (uses `webidl.util.markAsUncloneable`, a Node 22 API). The plugin runs under the sf CLI, installed via `npm install @salesforce/cli --global`, so it executes on the workflow's Node. On Node 20 the `Convert Apex coverage to LCOV` step crashes with `TypeError: webidl.util.markAsUncloneable is not a function`.

Matches the reusable workflow's default (`node-version: '22'`).