### PR TITLE
docs: enable clean URLs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
   "buildCommand": "npm run docs:build",
-  "outputDirectory": "website/.vitepress/dist"
+  "outputDirectory": "website/.vitepress/dist",
+  "cleanUrls": true
 }

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vitepress";
 
 export default defineConfig({
+  cleanUrls: true,
   title: "Test Lib",
   description:
     "Apex test data builder library with Builder and Mocker patterns for creating test records in Salesforce",


### PR DESCRIPTION
Enables VitePress `cleanUrls` so docs pages resolve without the `.html` suffix, consistent with our other documentation sites. Adds `\"cleanUrls\": true` to `vercel.json` and `cleanUrls: true` to the VitePress config.